### PR TITLE
fix(shtemplate): check length of nested statement/redirect arrays in injection detection

### DIFF
--- a/shtemplate/shtemplate.go
+++ b/shtemplate/shtemplate.go
@@ -31,8 +31,8 @@ import (
 	"unicode/utf8"
 
 	"github.com/google/safetext/common"
-	"mvdan.cc/sh/v3/syntax"
 	"github.com/pborman/uuid"
+	"mvdan.cc/sh/v3/syntax"
 )
 
 // ErrInvalidShTemplate indicates the requested template is not a valid script
@@ -787,6 +787,10 @@ func redirectsMatch(a, b, c *syntax.Redirect) bool {
 }
 
 func redirectsArrayMatch(a, b, c []*syntax.Redirect) bool {
+	if len(b) != len(a) || len(c) != len(a) {
+		return false
+	}
+
 	for i := range a {
 		if !redirectsMatch(a[i], b[i], c[i]) {
 			return false
@@ -825,6 +829,10 @@ func statementsMatch(a, b, c *syntax.Stmt) bool {
 }
 
 func statementsArrayMatch(a, b, c []*syntax.Stmt) bool {
+	if len(b) != len(a) || len(c) != len(a) {
+		return false
+	}
+
 	for i := range a {
 		if !statementsMatch(a[i], b[i], c[i]) {
 			return false

--- a/shtemplate/shtemplate_test.go
+++ b/shtemplate/shtemplate_test.go
@@ -318,6 +318,56 @@ fi`,
 			},
 			err: template.ErrShInjection,
 		},
+
+		// Command injection via a newline-separated statement inserted into a
+		// *nested* statement list (subshell). The top-level statement count is
+		// unchanged, so this is only caught if nested statement arrays also
+		// verify their length. A newline separator is used because the mutation
+		// pass doubles it to "\n\n", which stays valid shell (unlike ";").
+		{
+			tmplText: "(echo {{ .addressee }})",
+			replacements: map[any]any{
+				"addressee": "foo\ncommand",
+			},
+			err: template.ErrShInjection,
+		},
+
+		// Same, inside a brace block.
+		{
+			tmplText: "{ echo {{ .addressee }}; }",
+			replacements: map[any]any{
+				"addressee": "foo\ncommand",
+			},
+			err: template.ErrShInjection,
+		},
+
+		// Same, inside a command substitution.
+		{
+			tmplText: "out=$(grep {{ .addressee }})",
+			replacements: map[any]any{
+				"addressee": "foo\ncommand",
+			},
+			err: template.ErrShInjection,
+		},
+
+		// Same, inside an if-body.
+		{
+			tmplText: "if true; then echo {{ .addressee }}; fi",
+			replacements: map[any]any{
+				"addressee": "foo\ncommand",
+			},
+			err: template.ErrShInjection,
+		},
+
+		// Cross-check: a legitimate value inside a nested statement list must
+		// still pass after adding the length checks.
+		{
+			tmplText: "(echo {{ .addressee }})",
+			replacements: map[any]any{
+				"addressee": "hello",
+			},
+			err: nil,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
### Summary

`shtemplate`'s injection detection compares the baseline, requested, and mutated renders of a template structurally. Two of the array-comparison helpers — `statementsArrayMatch` and `redirectsArrayMatch` — iterate over the baseline array and index the other two **without first checking that all three arrays have the same length**:

```go
func statementsArrayMatch(a, b, c []*syntax.Stmt) bool {
	for i := range a {              // ranges over baseline only
		if !statementsMatch(a[i], b[i], c[i]) {
			return false
		}
	}
	return true
}
```

Every other array comparison in this package already does this check (`arithmExprArrayMatch`, `assignArrayMatch`, `caseItemArrayMatch`, `wordsArrayMatch`, `wordsMatch`), and so do the equivalent functions in the sibling `shsprintf` package (`shsprintf.go`'s `statementsArrayMatch`/`redirectsArrayMatch`). These two were the exception.

### Impact

The top-level `scriptsMatch` does length-check `File.Stmts`, so injection that adds **top-level** statements is caught. But extra statements/redirects added inside a **nested** statement list are routed through the two unchecked helpers (via `cmdSubstMatch`, `Subshell`, `Block`, `IfClause`, `WhileClause`, `ForClause`, `ProcSubst`, function bodies), so any entries beyond `len(baseline)` are never compared.

A newline works as the separator because the mutation pass doubles every rune and `"\n" -> "\n\n"` stays valid shell (whereas `";" -> ";;"` is a parse error that the mutation check already catches). For example, on current `main`:

```go
tmpl, _ := shtemplate.New("t").Parse("(echo {{.x}})")
var b bytes.Buffer
err := tmpl.Execute(&b, map[string]any{"x": "foo\ncommand"})
// err == nil, b == "(echo foo\ncommand)"  — the injected `command` is a second statement
```

The same shape via `shsprintf.Sprintf("(echo %s)\n", "foo\ncommand")` is correctly rejected, which is the inconsistency this PR removes.

### Fix

Add the same `len(b) == len(a) && len(c) == len(a)` guard used by the other helpers to both functions, and add regression tests covering the nested contexts (subshell, brace block, command substitution, if-body) plus a legitimate nested-value cross-check that must still pass.

`go test ./...` passes.

